### PR TITLE
New durations method + access key handling

### DIFF
--- a/src/Codelocks.php
+++ b/src/Codelocks.php
@@ -67,7 +67,7 @@ class Codelocks
 
         // Check that the accessKey is of the right form and at least 10
         // characters
-        if (!preg_match('/^[0-9a-z]{10,}$/', $accessKey)) {
+        if (!preg_match('/^[0-9a-z]{10,}$/', $accessKey) && !preg_match('/^[0-9]{6,}$/', $accessKey) && !is_null($accessKey)) {
             throw new \Exception('Invalid API access key');
         }
 
@@ -292,5 +292,23 @@ class Codelocks
             $netcode->accessKey($this->accessKey);
         }
         return $netcode;
+    }
+    
+    /**
+     * Return a list of durations
+     *
+     * Returns a list of durations or modes of operation for a given
+     * lock model.
+     *
+     * @param string $query     Lock model
+     * @param string $operation Specify DURATIONS to return all available
+     *                          durations for the given lock model or MODES
+     *                          to return all available NetCode modes for 
+     *                          the given lock model.
+     * @return Durations        A list lock durations.
+     */
+    public function durations()
+    {
+        return new Methods\Durations($this);
     }
 }

--- a/src/Methods/Durations.php
+++ b/src/Methods/Durations.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * API lock initialise method
+ */
+
+namespace drinkynet\Codelocks\Methods;
+
+class Durations extends ApiMethod
+{
+    protected $method = 'durations';
+
+    /**
+     * Define the required arguments for this method call
+     * @var array
+     */
+    protected $requiredArgs = ['query','operation'];
+
+    /**
+     * Return the init sequence data for the specified lock model
+     * @return array|false
+     */
+    public function get()
+    {
+        $result = $this->execute();
+        return $result;
+    }
+
+    /**
+     * Parameter config functions
+     */
+
+    /**
+     * Set the lock model for this init call
+     * @param  string $query The model identifier to request an init routine for
+     * @return this              Allow method chaining
+     */
+    public function query($query)
+    {
+        $this->args['query'] = $query;
+        return $this;
+    }
+
+    /**
+     * Set the operation for this durations call
+     * @param  string $operation The operation will select the correct action
+     * @return this               Allow method chaining
+     */
+    public function operation($operation)
+    {
+        $this->args['operation'] = $operation;
+        return $this;
+    }
+}


### PR DESCRIPTION
Summary of the changes:

Codelocks.php > Line 70 > public function __construct() > format check for access key amended to allow two additional formats (6 digit numeric and a null access key). This is to support KL series NetCode locks.
Codelocks.php > Line 297 > Additional method "durations" added
src/Durations.php > Additional method "durations"

The new durations method allows for a list of available durations for each NetCode lock model to be retrieved. The method allows for two operations: DURATIONS and MODES. Durations is the list of durations, modes is a list of unique NetCode modes that each lock supports.
